### PR TITLE
Apply patches to support upgrading Zepto monolith to active_interaction v4.1

### DIFF
--- a/active_interaction-extras.gemspec
+++ b/active_interaction-extras.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "active_interaction", ">= 4.0.2"
+  spec.add_dependency "active_interaction", ">= 4.0.2", "<5"
   spec.add_dependency "activemodel", ">= 6.0"
   spec.add_dependency "activesupport", ">= 6.0"
 

--- a/lib/active_interaction/extras/model_fields.rb
+++ b/lib/active_interaction/extras/model_fields.rb
@@ -72,6 +72,8 @@ module ActiveInteraction::Extras::ModelFields
   # overwritten to pre-populate model fields
   def populate_filters_and_inputs(_inputs)
     super.tap do
+      @_interaction_inputs = ActiveInteraction::Inputs.new(@_interaction_inputs.dup)
+
       self.class.filters.each do |name, filter|
         next if given?(name)
 
@@ -79,8 +81,11 @@ module ActiveInteraction::Extras::ModelFields
         next if model_field.nil?
 
         value = public_send(model_field)&.public_send(name)
+        @_interaction_inputs[name] = value
         public_send("#{name}=", filter.clean(value, self))
       end
+
+      @_interaction_inputs.freeze
     end
   end
 

--- a/lib/active_interaction/extras/strong_params.rb
+++ b/lib/active_interaction/extras/strong_params.rb
@@ -3,7 +3,10 @@ module ActiveInteraction::Extras::StrongParams
 
   def initialize(inputs = {})
     # TODO: whitelist :params and :form_params, so they could not be used as filters
-    return super if self.class.filters.key?(:params) || self.class.filters.key?(:form_params)
+    return super if
+      self.class.filters.key?(:params) ||
+      self.class.filters.key?(:form_params) ||
+      !%i[fetch key? merge].all? { |m| inputs.respond_to? m }
 
     if inputs.key?(:params) && inputs.key?(:form_params)
       raise ArgumentError, 'Both options :params and :form_params are given. ' \

--- a/spec/lib/model_fields_spec.rb
+++ b/spec/lib/model_fields_spec.rb
@@ -15,34 +15,30 @@ RSpec.describe ActiveInteraction::Extras::ModelFields do
     end
 
     describe '#model_fields' do
-      context 'new object' do
-        it 'prepopulates fields' do
-          model = double('Model', date_field: Date.today)
-          result = test_form_class.new(model: model)
+      subject(:model_fields) { interaction.model_fields(:model) }
 
-          expect(result.date_field).to eq Date.today
+      let(:interaction) { test_form_class.new(**interaction_args) }
+      let(:interaction_args) { {model: model} }
+      let(:model) { double('Model', date_field: Date.today) }
+
+      it 'returns values from given model' do
+        expect(model_fields).to eq(date_field: Date.today)
+      end
+
+      context 'with nil value for model field argument' do
+        let(:interaction_args) { {model: model, date_field: nil} }
+
+        it 'sets model field value to nil' do
+          expect(model_fields).to eq(date_field: nil)
         end
       end
 
-      it 'prepopulates model fields' do
-        model = double('Model', date_field: Date.today)
-        result = test_form_class.run!(model: model)
+      context 'with empty string value for model field argument' do
+        let(:interaction_args) { {model: model, date_field: ''} }
 
-        expect(result).to eq Date.today
-      end
-
-      it 'sets to nil' do
-        model = double('Model', date_field: Date.today)
-        result = test_form_class.run!(model: model, date_field: nil)
-
-        expect(result).to be_nil
-      end
-
-      it 'sets empty string to nil' do
-        model = double('Model', date_field: Date.today)
-        result = test_form_class.run!(model: model, date_field: '')
-
-        expect(result).to be_nil
+        it 'sets model field value to nil' do
+          expect(model_fields).to eq(date_field: nil)
+        end
       end
     end
 

--- a/spec/lib/strong_params_spec.rb
+++ b/spec/lib/strong_params_spec.rb
@@ -102,4 +102,10 @@ RSpec.describe ActiveInteraction::Extras::StrongParams do
       expect(ParentScope::TestService.run!(params)).to eq(a: 1, b: 2)
     end
   end
+
+  context 'with invalid inputs object type' do
+    it 'raises ArgumentError' do
+      expect { klass.run(Object.new) }.to raise_error(ArgumentError)
+    end
+  end
 end


### PR DESCRIPTION
## 💡 Why
Ensures compatibility with v4.1 of `active_interaction` gem.

## 📝 What
Apply [patches](https://github.com/antulik/active_interaction-extras/pulls/kieranjogrady) that have been submitted to upstream project for review. The intention is to require this branch of our fork in our monolith's Gemfile until the upstream PRs are merged.